### PR TITLE
version 1.1.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.github.sharedeffort'
-version = '1.1.8'  // ← 버전 관리
+version = '1.1.9'  // ← 버전 관리
 description = 'common-module'
 
 // Spring Boot BOM만 import (버전 관리용)
@@ -53,6 +53,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -66,4 +67,14 @@ tasks.named('test') {
 // jar 태스크는 기본 설정으로 충분
 jar {
     enabled = true
+}
+
+// Javadoc Task
+tasks.withType(Javadoc).configureEach {
+    options.encoding = 'UTF-8'
+    options.charSet = 'UTF-8'
+}
+// Java Compile Task
+tasks.withType(JavaCompile).configureEach {
+    options.encoding = 'UTF-8'
 }

--- a/src/main/java/com/library/module/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/library/module/common/handler/GlobalExceptionHandler.java
@@ -1,38 +1,91 @@
 package com.library.module.common.handler;
 
+import com.library.module.exception.BaseErrorCode;
+import com.library.module.exception.CommonErrorCode;
 import com.library.module.exception.CustomException;
 import com.library.module.response.ApiResponse;
 import com.library.module.response.ErrorResponse;
-import org.springframework.http.HttpStatus;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    // CustomException이 발생했을 때 처리
+    // CustomException 처리
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException ex) {
+        BaseErrorCode errorCode = ex.getBaseErrorCode();
 
-        ErrorResponse errorBody = new ErrorResponse(e.getErrorCode(), e.getErrorMessage());
+        ErrorResponse errorResponse = new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
 
-        ApiResponse<?> apiResponse = ApiResponse.error(errorBody,"응답 실패");
-
-        // CustomException에 정의된 HTTP 상태 코드를 사용하여 응답
-        return ResponseEntity
-                .status(e.getHttpStatus())
-                .body(apiResponse);
+        return new ResponseEntity<>(
+                ApiResponse.error(errorResponse),
+                errorCode.getStatus()
+        );
     }
 
-    // 예상치 못한 시스템 예외 처리 (500 Internal Server Error)
-    @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<?>> handleGeneralException(Exception e) {
+    // MethodArgumentNotValidException Body, Valid 검증
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException ex) {
 
-        // 5000: 공통 시스템 오류 코드
-        ErrorResponse errorBody = new ErrorResponse(5000, "시스템 내부 오류가 발생했습니다.");
-        return ResponseEntity
-                .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(ApiResponse.error(errorBody));
+        String errorMessage = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getDefaultMessage())
+                .findFirst()
+                .orElse("입력 값이 올바르지 않습니다.");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                CommonErrorCode.INVALID_INPUT.getCode(),
+                errorMessage
+        );
+
+        return new ResponseEntity<>(
+                ApiResponse.error(errorResponse),
+                CommonErrorCode.INVALID_INPUT.getStatus()
+        );
+    }
+
+    // ConstraintViolationException 메서드 파라미터 검증
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolation(ConstraintViolationException e) {
+
+        String errorMessage = e.getConstraintViolations()
+                .stream()
+                .findFirst()
+                .map(violation -> violation.getMessage())
+                .orElse("입력 값이 올바르지 않습니다.");
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                CommonErrorCode.INVALID_INPUT.getCode(),
+                errorMessage
+        );
+
+        return new ResponseEntity<>(
+                ApiResponse.error(errorResponse),
+                CommonErrorCode.INVALID_INPUT.getStatus()
+        );
+    }
+
+    // RuntimeException 처리 (예상치 못한 에러)
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<?>> handleRuntimeException(RuntimeException ex) {
+        CommonErrorCode errorCode = CommonErrorCode.INTERNAL_ERROR;
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                errorCode.getCode(),
+                errorCode.getMessage()
+        );
+
+        return new ResponseEntity<>(
+                ApiResponse.error(errorResponse),
+                errorCode.getStatus()
+        );
     }
 }

--- a/src/main/java/com/library/module/exception/BaseErrorCode.java
+++ b/src/main/java/com/library/module/exception/BaseErrorCode.java
@@ -1,0 +1,10 @@
+package com.library.module.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+
+    HttpStatus getStatus();
+    String getMessage();
+    int getCode();
+}

--- a/src/main/java/com/library/module/exception/CommonErrorCode.java
+++ b/src/main/java/com/library/module/exception/CommonErrorCode.java
@@ -1,0 +1,30 @@
+package com.library.module.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CommonErrorCode implements BaseErrorCode{
+
+    /**
+     * 공통 error -> 1000번대
+     */
+    INTERNAL_ERROR(1000, HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류가 발생했습니다."),
+    INVALID_INPUT(1001, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    UNAUTHORIZED(1002, HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
+    FORBIDDEN(1003, HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(1004, HttpStatus.NOT_FOUND, "요청하신 리소스를 찾을 수 없습니다."),
+
+
+
+
+
+
+    ;
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/library/module/exception/CustomException.java
+++ b/src/main/java/com/library/module/exception/CustomException.java
@@ -1,21 +1,14 @@
 package com.library.module.exception;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomException extends RuntimeException {
 
-    private final HttpStatus httpStatus;
+    private final BaseErrorCode baseErrorCode;
 
-    private final int errorCode;
-
-    private final String errorMessage;
-
-    public CustomException(HttpStatus httpStatus, int errorCode, String errorMessage) {
-        super(errorMessage);
-        this.httpStatus = httpStatus;
-        this.errorCode = errorCode;
-        this.errorMessage = errorMessage;
+    public CustomException(BaseErrorCode baseErrorCode) {
+        super(baseErrorCode.getMessage());
+        this.baseErrorCode = baseErrorCode;
     }
 }

--- a/src/main/java/com/library/module/response/ApiResponse.java
+++ b/src/main/java/com/library/module/response/ApiResponse.java
@@ -14,41 +14,42 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 public record ApiResponse<T>(
         boolean success,
         String message,
-        T data,
-        Long timestamp
+        T data
 ) {
+
     /**
      * 성공 응답 생성 (데이터 포함)
      */
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, null, data, System.currentTimeMillis());
+        return new ApiResponse<>(true, null, data);
     }
 
     /**
      * 성공 응답 생성 (데이터 + 메시지)
      */
     public static <T> ApiResponse<T> success(T data, String message) {
-        return new ApiResponse<>(true, message, data, System.currentTimeMillis());
+        return new ApiResponse<>(true, message, data);
     }
 
     /**
      * 성공 응답 생성 (메시지만)
      */
     public static <T> ApiResponse<T> success(String message) {
-        return new ApiResponse<>(true, message, null, System.currentTimeMillis());
+        return new ApiResponse<>(true, message, null);
     }
+
 
     /**
      * 실패 응답 생성 (에러 데이터)
      */
     public static <T> ApiResponse<T> error(T errorData) {
-        return new ApiResponse<>(false, null, errorData, System.currentTimeMillis());
+        return new ApiResponse<>(false, null, errorData);
     }
 
     /**
      * 실패 응답 생성 (에러데이터 + 메시지)
      */
     public static <T> ApiResponse<T> error(T errorData, String message) {
-        return new ApiResponse<>(false, message, errorData, System.currentTimeMillis());
+        return new ApiResponse<>(false, message, errorData);
     }
 }


### PR DESCRIPTION
- closed #1 

<br>

<img width="995" height="727" alt="스크린샷 2025-12-01 224348" src="https://github.com/user-attachments/assets/a0dd1272-34ad-490a-bd23-7bc0d01a7938" />

개선된 에러 응답 구조입니다. (테스트 시 응답에 에러 메세지가 안 뜸 -> 메서드 추가)
에러 코드는 처음 사용해보는데 이게 맞는 지,, 뭔가 묘한 구석이 있어서 먼저 pr로 올려두겠습니다! 
**사용 방법은 팀 노션 페이지 5분 기록 보드 참고해주세요 💡**
개선 사항 있으면 같이 이야기 나눠보아요.. 👻


✅ 에러 응답이 있어서 api 응답에서 실패 케이스는 빼고 에러 응답만 활용하는 것도 깔끔할 거 같은데 의견 주세요!

✅ 태그는 머지 후 붙여두겠습니다 🤔
```
순서 백업

git checkout main
git pull origin main
# 최신 커밋에 v1.1.9 태그 생성
git tag v1.1.9
# 태그를 원격 저장소로 푸시 (JitPack 배포 요청)
git push origin v1.1.9
```